### PR TITLE
Do not detect Claude Desktop instead of Claude Code

### DIFF
--- a/internal/marvai/marvai.go
+++ b/internal/marvai/marvai.go
@@ -50,8 +50,7 @@ func FindClaudeBinaryWithRunner(runner CommandRunner, fs afero.Fs, goos string, 
 	case "darwin":
 		securePaths = []string{
 			"/usr/local/bin/claude",
-			"/opt/homebrew/bin/claude",
-			"/Applications/Claude.app/Contents/MacOS/claude",
+			"/opt/homebrew/bin/claude"
 		}
 		// Only add user paths if homeDir is secure
 		if isSecureHomeDir(homeDir) {


### PR DESCRIPTION
Removed "/Applications" folder on mac since this cannot be the binary you are looking for.

This fixes it for me but i'd re-evaluate the whole approach:
- My Claude Code binary is in /Users/tonit/.nvm/versions/node/v18.16.0/bin/claude and so far marvai was finding /Applications/Claude.app/Contents/MacOS/claude (which is Claude Desktop).

This PR so far only fixes it for me. 

I'd argue that /opt/homebrew/bin/claude also cannot be correct since this also is a brew cask for claude desktop.

A better approach would be to check the file itself, e.g. look at the start of the claude executable because its a node binary it should look like "#!/usr/bin/env -S node" ?